### PR TITLE
feat: Add total counts to GET endpoints and fix createSchool bug

### DIFF
--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -21,7 +21,11 @@ exports.getStudents = async (req, res) => {
   const { schoolId } = req.params;
   try {
     const students = await Student.find({ schoolId });
-    res.json(students);
+    const total = await Student.countDocuments({ schoolId });
+    res.json({
+      total,
+      students,
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -41,14 +41,18 @@ exports.getUsersBySchool = async (req, res) => {
   const { schoolId } = req.params;
   try {
     const users = await User.find({ schoolId, role: 'admin' }); // Only return admins for the school
-    res.json(users.map(user => ({
-      id: user._id,
-      username: user.username,
-      role: user.role,
-      schoolId: user.schoolId,
-      email: user.email,
-      phoneNumber: user.phoneNumber,
-    })));
+    const total = await User.countDocuments({ schoolId, role: 'admin' });
+    res.json({
+      total,
+      users: users.map(user => ({
+        id: user._id,
+        username: user.username,
+        role: user.role,
+        schoolId: user.schoolId,
+        email: user.email,
+        phoneNumber: user.phoneNumber,
+      })),
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
- Modified `createSchool` controller to proactively check for existing schools with a case-insensitive search to prevent duplicate name errors.
- Updated the `getSchools`, `getStudents`, and `getUsersBySchool` controllers to include a 'total' count in the response, providing the total number of items being fetched.