### PR TITLE
I've fixed the `getUsersBySchool` route. Here's what I did:

### DIFF
--- a/src/routes/usersRoutes.js
+++ b/src/routes/usersRoutes.js
@@ -113,7 +113,7 @@ router.post('/', auth, roleCheck(['superadmin']), accessControl, usersController
  *       500:
  *         description: Server error
  */
-router.get('/users/:schoolId', auth, roleCheck(['superadmin']), accessControl, usersController.getUsersBySchool);
+router.get('/:schoolId', auth, roleCheck(['superadmin']), accessControl, usersController.getUsersBySchool);
 
 /**
  * @swagger


### PR DESCRIPTION
- Changed the route from `/users/:schoolId` to `/:schoolId` to avoid a routing conflict.
- The full path will now correctly resolve to `/users/:schoolId`.