### PR TITLE
fix: Handle missing school on admin login

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -24,15 +24,24 @@ exports.login = async (req, res) => {
       role: user.role,
     };
 
-    if (user.role === 'admin' && user.schoolId) {
-      const school = await School.findById(user.schoolId);
-      if (school) {
-        userResponse.school = {
-          id: school._id,
-          name: school.name,
-          logoUrl: school.logoUrl,
-          address: school.address,
-        };
+    if (user.role === 'admin') {
+      if (user.schoolId) {
+        const school = await School.findById(user.schoolId);
+        if (school) {
+          userResponse.school = {
+            id: school._id,
+            name: school.name,
+            logoUrl: school.logoUrl,
+            address: school.address,
+          };
+        } else {
+          // School not found, explicitly set to null
+          console.log(`Warning: Admin user ${user.username} has a schoolId ${user.schoolId} that was not found in the database.`);
+          userResponse.school = null;
+        }
+      } else {
+        // Admin has no schoolId
+        userResponse.school = null;
       }
     }
 


### PR DESCRIPTION
This commit fixes an issue where the login response for an admin user with an invalid `schoolId` would silently omit the `school` field.

The logic has been updated to explicitly return `school: null` in the response if the school is not found in the database. A warning is also logged on the server to help diagnose potential data integrity issues. This makes the API response more predictable and easier for clients to handle.