### PR TITLE
fix: Correct `schoolId` type in User model

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -8,7 +8,7 @@ const userSchema = new mongoose.Schema({
   phoneNumber: { type: String },
   password: { type: String, required: true },
   role: { type: String, enum: ['admin', 'superadmin'], required: true },
-  schoolId: { type: String, ref: 'School', required: function () { return this.role === 'admin'; } }, // Only admins have schoolId
+  schoolId: { type: mongoose.Schema.Types.ObjectId, ref: 'School', required: function () { return this.role === 'admin'; } }, // Only admins have schoolId
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
 });


### PR DESCRIPTION
This commit fixes a critical bug where the `schoolId` field in the `userSchema` was incorrectly defined as `type: String` instead of `type: mongoose.Schema.Types.ObjectId`.

This type mismatch caused database queries for the school document to fail during login, even when a valid ID was present. Correcting the schema type resolves the issue and ensures that school details are correctly returned in the login response for admin users.