### PR TITLE
feat: allow superadmin to view all users and students

### DIFF
--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -32,6 +32,19 @@ exports.getStudents = async (req, res) => {
   }
 };
 
+exports.getAllStudents = async (req, res) => {
+  try {
+    const students = await Student.find({});
+    const total = await Student.countDocuments({});
+    res.json({
+      total,
+      students,
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 exports.updateStudent = async (req, res) => {
   const { schoolId, rfid } = req.params;
   

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -57,6 +57,27 @@ exports.getUsersBySchool = async (req, res) => {
   }
 };
 
+exports.getUsers = async (req, res) => {
+  try {
+    // Superadmin gets all users
+    const users = await User.find({});
+    const total = await User.countDocuments({});
+    res.json({
+      total,
+      users: users.map(user => ({
+        id: user._id,
+        username: user.username,
+        role: user.role,
+        schoolId: user.schoolId,
+        email: user.email,
+        phoneNumber: user.phoneNumber,
+      })),
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 exports.updateUser = async (req, res) => {
   const { id } = req.params;
   const { username, password, role, schoolId, email, phoneNumber } = req.body;

--- a/src/routes/studentRoutes.js
+++ b/src/routes/studentRoutes.js
@@ -8,6 +8,28 @@ const accessControl = require('../middleware/accessControl');
 
 /**
  * @swagger
+ * /students:
+ *   get:
+ *     summary: Get all students
+ *     tags: [Students]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: A list of all students
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Student'
+ *       500:
+ *         description: Server error
+ */
+router.get('/', auth, roleCheck(['superadmin']), accessControl, studentController.getAllStudents);
+
+/**
+ * @swagger
  * /students/{schoolId}:
  *   post:
  *     summary: Create a new student

--- a/src/routes/usersRoutes.js
+++ b/src/routes/usersRoutes.js
@@ -8,6 +8,42 @@ const accessControl = require('../middleware/accessControl');
 
 /**
  * @swagger
+ * /:
+ *   get:
+ *     summary: Get all users
+ *     description: Retrieves a list of all users. Only superadmins can perform this action.
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: A list of users
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                   username:
+ *                     type: string
+ *                   role:
+ *                     type: string
+ *                   schoolId:
+ *                     type: string
+ *                   email:
+ *                     type: string
+ *                   phoneNumber:
+ *                     type: string
+ *       500:
+ *         description: Server error
+ */
+router.get('/', auth, roleCheck(['superadmin']), accessControl, usersController.getUsers);
+
+/**
+ * @swagger
  * /users:
  *   post:
  *     summary: Create a new user


### PR DESCRIPTION
This commit introduces new functionality for the superadmin role.

- Adds a new GET /users endpoint to allow superadmins to retrieve a list of all users in the system.
- Adds a new GET /students endpoint to allow superadmins to retrieve a list of all students across all schools.

The existing GET /schools endpoint already supported retrieving all schools for superadmins, so no changes were needed there.