### PR TITLE
Fix(student): Handle tab-delimited CSV files in student import

### DIFF
--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -102,6 +102,8 @@ exports.importStudents = [
       const csvData = fs.readFileSync(file.path, 'utf8');
       Papa.parse(csvData, {
         header: true,
+        delimiter: '\t',
+        skipEmptyLines: true,
         complete: async (result) => {
           const students = result.data.map((row) => ({
             schoolId, // Use the provided schoolId


### PR DESCRIPTION
The student import functionality was failing for tab-separated CSV files because the parser was expecting comma-separated values by default.

This change configures the `papaparse` library to use a tab (`\t`) as the delimiter, ensuring that tab-separated files are parsed correctly. It also adds `skipEmptyLines: true` as a safeguard against empty rows in the CSV.