### PR TITLE
Fix(student): De-duplicate CSV data before import

### DIFF
--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -114,7 +114,7 @@ exports.importStudents = [
             });
           }
 
-          const students = result.data.map((row) => ({
+          const rawStudents = result.data.map((row) => ({
             schoolId,
             rfid: row.rfid,
             name: row.name,
@@ -124,6 +124,13 @@ exports.importStudents = [
           })).filter(student =>
             student.rfid && student.name && student.admissionNumber && student.parentPhone
           );
+
+          // De-duplicate students by RFID, keeping the last occurrence.
+          const studentMap = new Map();
+          for (const student of rawStudents) {
+            studentMap.set(student.rfid, student);
+          }
+          const students = Array.from(studentMap.values());
 
           if (students.length === 0) {
             fs.unlinkSync(file.path);


### PR DESCRIPTION
Resolves a persistent `E11000 duplicate key` error during student CSV import. The error occurred when the source CSV file contained multiple entries with the same RFID. Even with an upsert operation, this caused a failure in the database batch operation.

This change introduces a de-duplication step that processes the student list after parsing and before the database write. It uses a Map to ensure that for any given RFID, only the last-seen entry from the CSV is processed.

This makes the import process resilient to duplicates in the source data and provides the most robust solution to the user's problem.