### PR TITLE
Feat(student): Make student RFID uniqueness per-school

### DIFF
--- a/src/models/student.js
+++ b/src/models/student.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 
 const studentSchema = new mongoose.Schema({
   schoolId: { type: String, required: true, ref: 'School' },
-  rfid: { type: String, required: true, unique: true },
+  rfid: { type: String, required: true },
   name: { type: String, required: true },
   admissionNumber: { type: String, required: true },
   parentPhone: { type: String, required: true },
@@ -15,5 +15,8 @@ const studentSchema = new mongoose.Schema({
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
 });
+
+// Create a compound unique index on rfid and schoolId
+studentSchema.index({ rfid: 1, schoolId: 1 }, { unique: true });
 
 module.exports = mongoose.model('Student', studentSchema);


### PR DESCRIPTION
Changes the core data model to make student RFIDs unique on a per-school basis, rather than globally unique. This allows different schools to use the same RFID values.

This was achieved by:
1. Modifying the database schema in `student.js` to drop the global unique index on `rfid` and add a compound unique index on `{ rfid, schoolId }`.
2. Auditing all database queries to ensure they are compatible with this change. The existing queries were already correctly scoped.
3. Ensuring the CSV import logic uses the compound key for its upsert operation.

This change was requested by the user to better fit their operational needs.