### PR TITLE
feat: Add super admin analytics route

### DIFF
--- a/src/controllers/analyticController.js
+++ b/src/controllers/analyticController.js
@@ -65,3 +65,61 @@ exports.getAnalytics = async (req, res) => {
     res.status(500).json({ message: error.message });
   }
 };
+
+exports.getSuperAdminAnalytics = async (req, res) => {
+  try {
+    // Student Analytics
+    const totalStudents = await Student.countDocuments({});
+
+    // Attendance Analytics
+    const attendanceToday = await Attendance.countDocuments({
+      timestamp: {
+        $gte: new Date(new Date().setHours(0, 0, 0, 0)),
+        $lte: new Date(new Date().setHours(23, 59, 59, 999)),
+      },
+    });
+    const lastWeekAttendance = await Attendance.countDocuments({
+      timestamp: {
+        $gte: new Date(new Date().setDate(new Date().getDate() - 7)),
+      },
+    });
+    const inCount = await Attendance.countDocuments({ event: 'in' });
+    const outCount = await Attendance.countDocuments({ event: 'out' });
+
+    // Message Analytics
+    const totalMessages = await Message.countDocuments({});
+    const messagesToday = await Message.countDocuments({
+      timestamp: {
+        $gte: new Date(new Date().setHours(0, 0, 0, 0)),
+        $lte: new Date(new Date().setHours(23, 59, 59, 999)),
+      },
+    });
+    const lastWeekMessages = await Message.countDocuments({
+      timestamp: {
+        $gte: new Date(new Date().setDate(new Date().getDate() - 7)),
+      },
+    });
+    const sentCount = await Message.countDocuments({ status: 'sent' });
+    const failedCount = await Message.countDocuments({ status: 'failed' });
+
+    res.json({
+      // Student Metrics
+      totalStudents,
+      // Attendance Metrics
+      attendanceToday,
+      lastWeekAttendance,
+      inCount,
+      outCount,
+      // Message Metrics
+      totalMessages,
+      messagesToday,
+      lastWeekMessages,
+      sentCount,
+      failedCount,
+      // General
+      lastUpdate: new Date(),
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/analyticsRoutes.js
+++ b/src/routes/analyticsRoutes.js
@@ -38,4 +38,32 @@ const accessControl = require('../middleware/accessControl');
  */
 router.get('/:schoolId', auth, roleCheck(['admin', 'superadmin']), accessControl, analyticsController.getAnalytics);
 
+/**
+ * @swagger
+ * /analytics/superadmin/all:
+ *   get:
+ *     summary: Get analytics for all schools (Super Admin only)
+ *     tags: [Analytics]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Aggregated analytics data for all schools
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 totalStudents:
+ *                   type: integer
+ *                 averageAttendance:
+ *                   type: number
+ *                   format: float
+ *       403:
+ *         description: Forbidden - User is not a Super Admin
+ *       500:
+ *         description: Server error
+ */
+router.get('/superadmin/all', auth, roleCheck(['superadmin']), accessControl, analyticsController.getSuperAdminAnalytics);
+
 module.exports = router;


### PR DESCRIPTION
This commit introduces a new API endpoint for super admins to fetch analytics data aggregated from all schools.

- A new controller function `getSuperAdminAnalytics` has been added to `src/controllers/analyticController.js`. This function is similar to `getAnalytics` but without the `schoolId` filter, allowing it to aggregate data from all schools.
- A new route `GET /analytics/superadmin/all` has been added to `src/routes/analyticsRoutes.js`. This route is protected by `auth`, `roleCheck(['superadmin'])`, and `accessControl` middleware.
- Swagger documentation has been added for the new route.