### PR TITLE
feat: Add ability to disable schools

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -12,6 +12,11 @@ exports.login = async (req, res) => {
     if (!user) {
       return res.status(400).json({ message: 'Invalid credentials' });
     }
+
+    const school = await School.findById(user.schoolId);
+    if (school?.disabled) {
+      return res.status(403).json({ message: 'Account deactivated' });
+    }
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
       return res.status(400).json({ message: 'Invalid credentials' });

--- a/src/controllers/schoolController.js
+++ b/src/controllers/schoolController.js
@@ -145,3 +145,27 @@ exports.getSchools = async (req, res) => {
     res.status(500).json({ message: error.message });
   }
 };
+
+exports.disableSchool = async (req, res) => {
+  try {
+    const school = await School.findByIdAndUpdate(req.params.id, { disabled: true }, { new: true });
+    if (!school) {
+      return res.status(404).json({ message: 'School not found' });
+    }
+    res.json({ message: 'School disabled successfully', school });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+exports.enableSchool = async (req, res) => {
+  try {
+    const school = await School.findByIdAndUpdate(req.params.id, { disabled: false }, { new: true });
+    if (!school) {
+      return res.status(404).json({ message: 'School not found' });
+    }
+    res.json({ message: 'School enabled successfully', school });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,8 +1,9 @@
 // middleware/auth.js
 const jwt = require('jsonwebtoken');
 const config = require('../config/config');
+const School = require('../models/school');
 
-const auth = (req, res, next) => {
+const auth = async (req, res, next) => {
   const token = req.header('Authorization')?.replace('Bearer ', '');
   if (!token) {
     return res.status(401).json({ message: 'No token provided' });
@@ -11,6 +12,10 @@ const auth = (req, res, next) => {
   try {
     const decoded = jwt.verify(token, config.jwtSecret);
     req.user = decoded;
+    const school = await School.findById(req.user.schoolId);
+    if (school?.disabled) {
+      return res.status(403).json({ message: 'Account deactivated' });
+    }
     next();
   } catch (error) {
     console.error('Token verification error:', error.message);

--- a/src/models/school.js
+++ b/src/models/school.js
@@ -13,6 +13,10 @@ const schoolSchema = new mongoose.Schema({
   logoUrl: { type: String }, // Optional
   address: { type: String }, // Optional
   admin: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: false },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
 });

--- a/src/routes/schoolRoutes.js
+++ b/src/routes/schoolRoutes.js
@@ -231,5 +231,7 @@ router.put('/:id', auth, roleCheck(['superadmin']), accessControl, schoolControl
  *                   example: "Server error"
  */
 router.get('/', auth, roleCheck(['admin', 'superadmin']), accessControl, schoolController.getSchools);
+router.put('/:id/disable', auth, roleCheck(['superadmin']), accessControl, schoolController.disableSchool);
+router.put('/:id/enable', auth, roleCheck(['superadmin']), accessControl, schoolController.enableSchool);
 
 module.exports = router;


### PR DESCRIPTION
This commit introduces the functionality to disable a school, preventing its users from accessing the application.

- A `disabled` field is added to the `School` model to track the status of a school.
- New API endpoints are created to allow a superadmin to disable and enable a school.
- The authentication middleware is updated to check the school's status on each request, blocking access for users of disabled schools.
- The login process is updated to prevent users from disabled schools from authenticating.