### PR TITLE
fix(auth): Ensure user response always has a school property

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -30,26 +30,22 @@ exports.login = async (req, res) => {
       userId: user._id,
       username: user.username,
       role: user.role,
+      school: null, // Initialize school as null
     };
 
-    if (user.role === 'admin') {
-      if (user.schoolId) {
-        const school = await School.findById(user.schoolId);
-        if (school) {
-          userResponse.school = {
-            id: school._id,
-            name: school.name,
-            logoUrl: school.logoUrl,
-            address: school.address,
-          };
-        } else {
-          // School not found, explicitly set to null
-          console.log(`Warning: Admin user ${user.username} has a schoolId ${user.schoolId} that was not found in the database.`);
-          userResponse.school = null;
-        }
+    if (user.role === 'admin' && user.schoolId) {
+      const school = await School.findById(user.schoolId);
+      if (school) {
+        userResponse.school = {
+          id: school._id,
+          name: school.name,
+          logoUrl: school.logoUrl,
+          address: school.address,
+        };
       } else {
-        // Admin has no schoolId
-        userResponse.school = null;
+        console.log(
+          `Warning: Admin user ${user.username} has a schoolId ${user.schoolId} that was not found in the database.`
+        );
       }
     }
 


### PR DESCRIPTION
The login endpoint was not consistently returning a `school` property in the user object for all user roles. This could cause a TypeError on the frontend if it attempts to access properties of an undefined `school` object.

This change modifies the `login` function in `authController.js` to initialize the `school` property to `null` for all users. If the user is an admin with a valid `schoolId`, the property is populated with the school's details. This ensures the frontend always receives a consistent user object structure, preventing the TypeError.