### PR TITLE
fix(auth): Add long-lived expiration to JWT

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -23,8 +23,8 @@ exports.login = async (req, res) => {
     }
     const token = jwt.sign(
       { id: user._id, role: user.role, schoolId: user.schoolId },
-      config.jwtSecret
-      // no expiresIn → token never expires
+      config.jwtSecret,
+      { expiresIn: '365d' }
     );
     const userResponse = {
       userId: user._id,


### PR DESCRIPTION
The removal of the JWT expiration caused login failures on client-side applications that expect an 'exp' claim in the token.

This commit re-introduces the expiration, setting it to 365 days. This makes the token long-lived while ensuring compatibility with client-side libraries that require an expiration claim.